### PR TITLE
Change of link to the LICENSE file

### DIFF
--- a/app/src/main/kotlin/cz/lastaapps/menza/features/other/ui/widgets/LibraryList.kt
+++ b/app/src/main/kotlin/cz/lastaapps/menza/features/other/ui/widgets/LibraryList.kt
@@ -73,7 +73,7 @@ private fun AppLicenseButton(modifier: Modifier = Modifier) {
     OutlinedButton(
         onClick = {
             Logger.withTag("AppLicenseButton").i { "Opening app license" }
-            url.openUri("https://github.com/Lastaapps/cvutbus/LICENSE")
+            url.openUri("https://github.com/Lastaapps/menza/blob/main/LICENSE")
         },
         modifier = modifier,
     ) {

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -220,7 +220,7 @@
     <string name="ui_top_bar_action_description">Další</string>
     <string name="ui_top_bar_action_privacy">Ochrana soukromí</string>
     <string name="ui_top_bar_action_license">Použité knihovny</string>
-    <string name="ui_top_bar_action_web_agata">We Agáty</string>
+    <string name="ui_top_bar_action_web_agata">Web Agáty</string>
     <string name="ui_top_bar_action_web_buffet">Web bufetů</string>
     <string name="ui_top_bar_action_web_vscht">Web Zíkova</string>
     <string name="menza_none_selected">Není vybrána žádná menza</string>


### PR DESCRIPTION
Původní link k licenci ([https://github.com/Lastaapps/cvutbus/LICENSE](https://github.com/Lastaapps/cvutbus/LICENSE)) mi nefunguje, GitHub nejspíš už nepodporuje linky bez branchů nebo tagů. Navrhuji tedy použít link na LICENSE soubor v main branchi: [https://github.com/Lastaapps/menza/blob/main/LICENSE](https://github.com/Lastaapps/menza/blob/main/LICENSE)

Alternativně by bylo možné použít link (přímo na text licence gpl-3.0): [https://www.gnu.org/licenses/gpl-3.0.html#license-text](https://www.gnu.org/licenses/gpl-3.0.html#license-text)